### PR TITLE
TinyUSB Arduino CDC library for µCNC

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,8 @@
+tusb_cdc_init	KEYWORD2
+tusb_cdc_isr_handler	KEYWORD2
+tusb_cdc_task	KEYWORD2
+tusb_cdc_available	KEYWORD2
+tusb_cdc_read	KEYWORD2
+tusb_cdc_flush	KEYWORD2
+tusb_cdc_write	KEYWORD2
+tusb_cdc_write_available	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=uCNC-tinyusb
+version=0.15.0
+author=Ha Thach
+maintainer=Ha Thach
+sentence=TinyUSB Arduino CDC library for uCNC.
+paragraph=TinyUSB Arduino CDC library for uCNC.
+category=Communication
+url=https://github.com/Paciente8159/uCNC-tinyusb/
+architectures=*
+includes=tusb_ucnc.h
+depends=

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -1,0 +1,154 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//--------------------------------------------------------------------
+// µCNC CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUSB_MCU
+// STM32
+#ifdef ARDUINO_ARCH_STM32
+#ifdef STM32F1xx
+#define CFG_TUSB_MCU OPT_MCU_STM32F1
+#endif
+#ifdef STM32F4xx
+#define CFG_TUSB_MCU OPT_MCU_STM32F4
+#endif
+#ifdef STM32F7xx
+#define CFG_TUSB_MCU OPT_MCU_STM32F7
+#endif
+#endif
+// SAMD21
+#if (defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_SAM_ZERO))
+#define CFG_TUSB_MCU OPT_MCU_SAMD21
+#endif
+// LPC176x
+#ifdef ARDUINO_ARCH_LPC176X
+#define CFG_TUSB_MCU OPT_MCU_LPC175X_6X
+#endif
+// Raspberry Pi Pico
+#ifdef ARDUINO_ARCH_RP2040
+#define CFG_TUSB_MCU OPT_MCU_RP2040
+#endif
+#endif
+
+#ifndef CFG_TUSB_MCU
+#define CFG_TUSB_MCU OPT_MCU_NONE
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+// defined by board.mk
+#ifndef CFG_TUSB_MCU
+#error CFG_TUSB_MCU must be defined
+#endif
+
+// RHPort number used for device can be defined by board.mk, default to port 0
+#ifndef BOARD_DEVICE_RHPORT_NUM
+#define BOARD_DEVICE_RHPORT_NUM 0
+#endif
+
+// force Full speed mode
+#define BOARD_DEVICE_RHPORT_SPEED OPT_MODE_FULL_SPEED
+
+// RHPort max operational speed can defined by board.mk
+// Default to Highspeed for MCU with internal HighSpeed PHY (can be port specific), otherwise FullSpeed
+#ifndef BOARD_DEVICE_RHPORT_SPEED
+#if (CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX || \
+     CFG_TUSB_MCU == OPT_MCU_NUC505 || CFG_TUSB_MCU == OPT_MCU_CXD56)
+#define BOARD_DEVICE_RHPORT_SPEED OPT_MODE_HIGH_SPEED
+#else
+#define BOARD_DEVICE_RHPORT_SPEED OPT_MODE_FULL_SPEED
+#endif
+#endif
+
+// Device mode with rhport and speed defined by board.mk
+#if BOARD_DEVICE_RHPORT_NUM == 0
+#define CFG_TUSB_RHPORT0_MODE (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
+#elif BOARD_DEVICE_RHPORT_NUM == 1
+#define CFG_TUSB_RHPORT1_MODE (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
+#else
+#error "Incorrect RHPort configuration"
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS OPT_OS_NONE
+#endif
+
+// CFG_TUSB_DEBUG is defined by compiler in DEBUG build
+// #define CFG_TUSB_DEBUG           0
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN __attribute__((aligned(4)))
+#endif
+
+  //--------------------------------------------------------------------
+  // DEVICE CONFIGURATION
+  //--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
+
+//------------- CLASS -------------//
+#define CFG_TUD_CDC 1
+#define CFG_TUD_MSC 0
+#define CFG_TUD_HID 0
+#define CFG_TUD_MIDI 0
+#define CFG_TUD_VENDOR 0
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+// CDC Endpoint transfer buffer size, more is faster
+#define CFG_TUD_CDC_EP_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/src/tusb_descriptors.c
+++ b/src/tusb_descriptors.c
@@ -1,0 +1,183 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb.h"
+
+/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
+ * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
+ *
+ * Auto ProductID layout's Bitmap:
+ *   [MSB]       MIDI | HID | MSC | CDC          [LSB]
+ */
+#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
+#define USB_PID (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                 _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4))
+
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t const desc_device =
+    {
+        .bLength = sizeof(tusb_desc_device_t),
+        .bDescriptorType = TUSB_DESC_DEVICE,
+        .bcdUSB = 0x0200,
+
+        // Use Interface Association Descriptor (IAD) for CDC
+        // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
+        .bDeviceClass = TUSB_CLASS_MISC,
+        .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+        .bDeviceProtocol = MISC_PROTOCOL_IAD,
+        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+        .idVendor = 0xCafe,
+        .idProduct = USB_PID,
+        .bcdDevice = 0x0100,
+
+        .iManufacturer = 0x01,
+        .iProduct = 0x02,
+        .iSerialNumber = 0x03,
+
+        .bNumConfigurations = 0x01};
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const *tud_descriptor_device_cb(void)
+{
+  return (uint8_t const *)&desc_device;
+}
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+enum
+{
+  ITF_NUM_CDC_0 = 0,
+  ITF_NUM_CDC_0_DATA,
+  ITF_NUM_TOTAL
+};
+
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN)
+
+#if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
+// LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
+// 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
+#define EPNUM_CDC_0_NOTIF 0x81
+#define EPNUM_CDC_0_DATA 0x02
+#else
+#define EPNUM_CDC_0_NOTIF 0x81
+#define EPNUM_CDC_0_DATA 0x02
+#endif
+
+uint8_t const desc_fs_configuration[] =
+    {
+        // Config number, interface count, string index, total length, attribute, power in mA
+        TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+
+        // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+        TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_DATA, 0x80 | EPNUM_CDC_0_DATA, 64),
+};
+
+#if TUD_OPT_HIGH_SPEED
+uint8_t const desc_hs_configuration[] =
+    {
+        // Config number, interface count, string index, total length, attribute, power in mA
+        TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+
+        // 1st CDC: Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+        TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_0, 4, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_DATA, 0x80 | EPNUM_CDC_0_DATA, 512),
+};
+#endif
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+{
+  (void)index; // for multiple configurations
+
+#if TUD_OPT_HIGH_SPEED
+  // Although we are highspeed, host may be fullspeed.
+  return (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_hs_configuration : desc_fs_configuration;
+#else
+  return desc_fs_configuration;
+#endif
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+// array of pointer to string descriptors
+char const *string_desc_arr[] =
+    {
+        (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
+        "uCNC",                  // 1: Manufacturer
+        "uCNC Device",           // 2: Product
+        "123456",                   // 3: Serials, should use chip ID
+        "uCNC CDC",              // 4: CDC Interface
+};
+
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+  (void)langid;
+
+  uint8_t chr_count;
+
+  if (index == 0)
+  {
+    memcpy(&_desc_str[1], string_desc_arr[0], 2);
+    chr_count = 1;
+  }
+  else
+  {
+    // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+    if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
+      return NULL;
+
+    const char *str = string_desc_arr[index];
+
+    // Cap at max char
+    chr_count = strlen(str);
+    if (chr_count > 31)
+      chr_count = 31;
+
+    // Convert ASCII string into UTF-16
+    for (uint8_t i = 0; i < chr_count; i++)
+    {
+      _desc_str[1 + i] = str[i];
+    }
+  }
+
+  // first byte is length (including header), second byte is string type
+  _desc_str[0] = (TUSB_DESC_STRING << 8) | (2 * chr_count + 2);
+
+  return _desc_str;
+}

--- a/src/tusb_ucnc.h
+++ b/src/tusb_ucnc.h
@@ -1,0 +1,44 @@
+/*
+	Name: tusb_ucnc.h
+	Description: TinyUSB CDC for µCNC.
+
+	Copyright: Copyright (c) João Martins
+	Author: João Martins
+	Date: 21-03-2023
+
+	µCNC is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+
+	µCNC is distributed WITHOUT ANY WARRANTY;
+	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the	GNU General Public License for more details.
+*/
+
+
+#ifndef _TUSB_UCNC_H_
+#define _TUSB_UCNC_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "tusb_config.h"
+#include "tusb.h"
+
+#define tusb_cdc_init tusb_init
+#define tusb_cdc_isr_handler() tud_int_handler(0)
+#define tusb_cdc_task tud_task
+#define tusb_cdc_available() tud_cdc_n_available(0)
+#define tusb_cdc_read() tud_cdc_n_read_char(0)
+#define tusb_cdc_flush() tud_cdc_n_write_flush(0)
+#define tusb_cdc_write(ch) tud_cdc_n_write_char(0, ch)
+#define tusb_cdc_write_available() tud_cdc_n_write_available(0);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_UCNC_H_ */


### PR DESCRIPTION
**Describe the PR**
Integrates TinyUSB as a custom Arduino CDC library to use with µCNC

